### PR TITLE
Multiple locale files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "translation-reference-for-i18n-json",
   "displayName": "Translation Reference for i18n JSON Files",
   "description": "Quick lookup, search, and copy translation text nested in a json file.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "icon": "translation_extension_icon.png",
   "author": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
       "title": "JsonTextLookup",
       "properties": {
         "translation-reference-for-i18n-json.jsonFilePath": {
-          "type": "string",
-          "default": "./data.json",
+          "type": "array",
+          "default": [
+            "./data.json"
+          ],
           "description": "Path to the JSON file used for hover tooltips"
         }
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,14 +17,24 @@ export const jsonSearchReferences = () =>
     }
   );
 
-export const findAllSearch = (jsonFilePath: string) =>
+export const findAllSearch = (jsonFilePath: string[]) =>
   vscode.commands.registerCommand("extension.findAllSearch", async () => {
     const searchTerm = await vscode.window.showInputBox({
       prompt: "Enter your search term",
     });
 
     if (searchTerm) {
-      const results = performSearch(searchTerm, jsonFilePath);
-      await searchForComponent(results);
+      const output = jsonFilePath
+        .map((filePath) => {
+          return performSearch(searchTerm, filePath);
+        })
+        .flat();
+
+      if (output) {
+        const results = await searchForComponent(output);
+        return results;
+      }
+
+      return [];
     }
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,13 +13,12 @@ export function activate(context: vscode.ExtensionContext) {
   const {
     jsonFilePath,
     err,
-  }: { jsonFilePath: string[] | undefined; err: vscode.Hover | undefined } =
+  }: { jsonFilePath: string[]; err: vscode.Hover | undefined } =
     getJsonFilePath();
 
   if (!jsonFilePath || err) {
     return err;
   }
-
   const reloadOnSettingsChange = vscode.workspace.onDidChangeConfiguration(
     (event) => {
       if (event.affectsConfiguration(APP_NAME)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
   const {
     jsonFilePath,
     err,
-  }: { jsonFilePath: string | undefined; err: vscode.Hover | undefined } =
+  }: { jsonFilePath: string[] | undefined; err: vscode.Hover | undefined } =
     getJsonFilePath();
 
   if (!jsonFilePath || err) {

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -47,7 +47,9 @@ export default (jsonFilePath: string[]) => {
               const markdownString = new vscode.MarkdownString(
                 `<h4>Translation:</h4>\n\n${
                   subtext.translation
-                }\n\n**[View in file](${uri.toString()})**`
+                }\n\n**[View in file](${uri.toString()})** - **[Copy text](command:extension.copyText?${encodeURIComponent(
+                  JSON.stringify([`"${splitWord.join(".")}"`])
+                )})**`
               );
               markdownString.supportHtml = true;
               markdownString.isTrusted = true;

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -8,7 +8,7 @@ import {
   nestedObjRef,
 } from "./utils";
 
-export default (jsonFilePath: string) => {
+export default (jsonFilePath: string[]) => {
   return vscode.languages.registerHoverProvider(
     [
       { scheme: "file", language: "javascript" },
@@ -30,27 +30,35 @@ export default (jsonFilePath: string) => {
         }
 
         try {
-          const doc = fs.readFileSync(jsonFilePath, "utf8");
-          const jsonData = JSON.parse(doc);
-          const subtext = nestedObjRef(jsonData, splitWord);
+          const output = jsonFilePath
+            .map((filePath) => {
+              const doc = fs.readFileSync(filePath, "utf8");
+              const jsonData = JSON.parse(doc);
+              const subtext = nestedObjRef(jsonData, splitWord);
 
-          if (!subtext?.translation) {
-            return undefined;
-          }
+              if (!subtext?.translation) {
+                return undefined;
+              }
 
-          const lineNumber = getLineOfMatch(doc, subtext.translation);
-          const uri = vscode.Uri.file(jsonFilePath).with({
-            fragment: `L${lineNumber}`,
-          });
-          const markdownString = new vscode.MarkdownString(
-            `<h4>Translation:</h4>\n\n${
-              subtext.translation
-            }\n\n**[View in file](${uri.toString()})**`
-          );
-          markdownString.supportHtml = true;
-          markdownString.isTrusted = true;
+              const lineNumber = getLineOfMatch(doc, subtext.translation);
+              const uri = vscode.Uri.file(filePath).with({
+                fragment: `L${lineNumber}`,
+              });
+              const markdownString = new vscode.MarkdownString(
+                `<h4>Translation:</h4>\n\n${
+                  subtext.translation
+                }\n\n**[View in file](${uri.toString()})**`
+              );
+              markdownString.supportHtml = true;
+              markdownString.isTrusted = true;
 
-          return new vscode.Hover(markdownString);
+              return markdownString;
+            })
+            .filter((x) => x);
+
+          return output?.[0]
+            ? new vscode.Hover(output[0])
+            : new vscode.Hover("");
         } catch (e) {
           console.log(e, "ERROR");
           return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,17 +34,14 @@ export const getJsonFilePath = () => {
   let err,
     jsonFilePath: string | string[] | undefined = config.get(JSON_PATH_SETTING);
 
-  const jsonFilePathArray: (string | undefined)[] = Array.isArray(jsonFilePath)
-    ? jsonFilePath
-    : [jsonFilePath];
-
-  const validPaths: (string | undefined)[] = jsonFilePathArray.filter(
-    (filePath) => filePath && fs.existsSync(filePath)
-  );
+  const jsonFilePathArray: string[] = Array.isArray(jsonFilePath)
+    ? jsonFilePath || ""
+    : [jsonFilePath || ""];
+  const validPaths: string[] = jsonFilePathArray.filter((filePath) => filePath);
 
   if (!jsonFilePath || validPaths.length === 0) {
     err = new vscode.Hover("JSON file not found. Check your path setting.");
-    return { jsonFilePath, err };
+    return { jsonFilePath: jsonFilePathArray, err };
   }
 
   const workspaceFolder = vscode.workspace.workspaceFolders
@@ -53,7 +50,7 @@ export const getJsonFilePath = () => {
 
   if (!workspaceFolder) {
     err = new vscode.Hover("Workspace folder not found.");
-    return { jsonFilePath, err };
+    return { jsonFilePath: jsonFilePathArray, err };
   }
 
   const output = validPaths.map((filePath) => {


### PR DESCRIPTION
Update settings to take an array of translation files. For collisions of translation keys, the first match will be referenced (i.e. the first of any duplicate searches is surfaced). This still works when a single file path as a string is used as a setting too.

This also adds the "Copy text" command on the translation hover over, previously this functionality was only shown in the translation json file hover over.
<img width="575" alt="image" src="https://github.com/user-attachments/assets/c5aeabd7-d33b-471f-a4dd-ad388f8851e0" />
